### PR TITLE
Position and forward is not available in observed player data

### DIFF
--- a/tsc/index.ts
+++ b/tsc/index.ts
@@ -177,9 +177,7 @@ class CSGOGSI {
 
 		const observer: Observer = {
 			activity: raw.player.activity,
-			spectarget: raw.player.spectarget,
-			position: raw.player.position.split(', ').map(n => Number(n)),
-			forward: raw.player.forward.split(', ').map(n => Number(n))
+			spectarget: raw.player.spectarget
 		};
 
 		const data: CSGO = {

--- a/tsc/parsed.d.ts
+++ b/tsc/parsed.d.ts
@@ -84,8 +84,6 @@ export interface Round {
 export interface Observer {
 	activity: 'playing' | 'textinput' | 'menu';
 	spectarget: 'free' | string;
-	position: number[];
-	forward: number[];
 }
 
 export interface CSGO {


### PR DESCRIPTION
Player: steamid: String, name: String, observer_slot: Number, team: 'CT' | 'T', activity: 'playing' | 'menu' | 'textinput'